### PR TITLE
Fixed key hashed values (see #2)

### DIFF
--- a/srptools/common.py
+++ b/srptools/common.py
@@ -22,7 +22,7 @@ class SRPSessionBase(object):
 
         self._salt = None  # type: int
         self._common_secret = None  # type: int
-        self._key = None  # type: int
+        self._key = None  # type: bytes
         self._key_proof = None  # type: bytes
         self._key_proof_hash = None  # type: bytes
 

--- a/srptools/context.py
+++ b/srptools/context.py
@@ -144,9 +144,9 @@ class SRPContext(object):
         """K = H(S)
 
         :param int premaster_secret:
-        :rtype: int
+        :rtype: bytes
         """
-        return self.hash(premaster_secret)
+        return self.hash(premaster_secret, as_bytes=True)
 
     def get_server_premaster_secret(self, password_verifier, server_private, client_public, common_secret):
         """S = (A * v^u) ^ b % N
@@ -213,7 +213,7 @@ class SRPContext(object):
     def get_common_session_key_proof(self, session_key, salt, server_public, client_public):
         """M = H(H(N) XOR H(g) | H(U) | s | A | B | K)
 
-        :param int session_key:
+        :param bytes session_key:
         :param int salt:
         :param int server_public:
         :param int client_public:
@@ -234,7 +234,7 @@ class SRPContext(object):
     def get_common_session_key_proof_hash(self, session_key, session_key_proof, client_public):
         """H(A | M | K)
 
-        :param int session_key:
+        :param bytes session_key:
         :param bytes session_key_proof:
         :param int client_public:
         :rtype: bytes

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -52,7 +52,7 @@ def test_context():
         '0876E2D013800D6C41BB59B6D5979B5C00A172B4A2A5903A0BDCAF8A709585EB2AFAFA8F3499B200210DCC1F10EB3394'
         '3CD67FC88A2F39A4BE5BEC4EC0A3212DC346D7E474B29EDE8A469FFECA686E5A')
 
-    expected_session_key = '017EEFA1CEFC5C2E626E21598987F31E0F1B11BB'
+    expected_session_key = b'017EEFA1CEFC5C2E626E21598987F31E0F1B11BB'
 
     server_premaster_secret = context.get_server_premaster_secret(
         password_verifier, static_server_private, client_public, common_secret)
@@ -129,7 +129,7 @@ def test_byte_hashes():
         password_hash, server_public, static_client_private, common_secret)
     assert hex_from(client_premaster_secret) == expected_premaster_secret
 
-    expected_session_key = '86a5aff58ae7eca772b05bbb629f5b1c51677b14'
+    expected_session_key = b'86a5aff58ae7eca772b05bbb629f5b1c51677b14'
 
     server_session_key = context.get_common_session_key(server_premaster_secret)
     assert hex_from(server_session_key) == expected_session_key


### PR DESCRIPTION
After testing the latest master, the failure rate went down significantly. However after running the tests for an extended amount of time, another incompatibility was found. The srptools server couldn't verify the client's proof (M). I found that the session key (K) had leading 0's in the hash, so that's probably causing the server to expect another M.

```
username: bouke
password: test
group: N1024
algorithm: sha256
salt: 9648b3bf78de7bb6
verificationKey: d376d398fd7de9f905481a19c266dad5a474e7884bb70540938f287e24beae9b41c87d46c001f27483d51df08001d906baa5caa33ea5112c1d582a6b6e82bd7bc883eab813cfc5f8dc2d03088229ec73ba65cdeb79e5dd8a8b683aeeb0b29a1ed953352075cf8031f532807d835986e5c152c60118173e2a37cd78f04fd7f6e0
serverPrivateKey: b00621dca906a8ed1db68f7ac99eb7d40272282d7248bee267acca73cda2dba8a560d7b71b61dc039e69b3ef97ba4cb9cda1047908e4d5b34dc851c9d387065b756eb8f68c55300defe4b64bc2a47242c883976cb12820e58a296ae62341d2fac2735603fa872f75882b1ef1fc0f9a2961b51168d19842421d2201d605cef95b
serverPublicKey: 4179ef2bac4a7e3cf318377953e6b148fc765c533a7f81c223dc6793fc9be797d5d428a82eac5921705e635b2af4c9ebc63440087450bd7c13bf807230d6d86767b14defa97ebcbdff4e87e659469b4630e65be188599b74acb96fe81b21d0f8e0f3655b6c069bf27b674611f2b271024e9694391b03541f1c30de10f6f351d7
clientPrivateKey: 5a8b4a1e00f02dce210c6ca9447452dff3b882914ae8aa4eca9814d4f33720d3c57e8fbf4fe12270fb8241c320e030bbfd6f3e512acaed62fd5bcdeb68f1c3d7e737c8f7610a49775acf0e5d60b2d827d1308b123e0861578a7438e37cee7a22cb7ba8c2c9eab35835960b3b2143cc80ce4666ab90fe29d6eda4975c3d92e5ef
clientPublicKey: 07e99787846760b90cac044d30f9f18569d717cc48866a2f539156428532477304bc327c5b70d926cd391d9146398d407a53b8c1a37df36573fd06d88db3041ec8a603887726c045a41e1d8178f26aeace311da8a001e4b7919f2edf2e3318d582706b5fd6314c07c883f8b7ca7002acbaa7bdd6f836d80f5de0bfd6d6472114
expected client M: f3ca03b86066c2c0e8f17ed9c3fdd1430befdd8eee7473d21031435ad1eeef22
expected server HAMK: 977bc450cfa77af5c48026fc78efe90d8e250266773d8dc54765a7394f794984
clientK: 00b8373cf72a1bf7d47d02f0aa83c1d2a2e6e6e8a3a239d123a3e65f908048ad
         ^^
clientM: 79108f17829a30862669de084275cf3939ba76170aa3438d955210bb4188c45a
```

another test case:
```
username: bouke
password: test
group: N3072
algorithm: sha1
salt: 6aa282873e3e6b09
verificationKey: d039007d3a9a0f4c99683783be5cddfb7d305af2c9c6dd62659ea96ce51c289dd6e968b13851a1235f77bde81aa5a7c4c0645976fe79d2c9925421fa348588fd0423be79abef5f7e832e917231846c739a4c043a2f98c13d327a234d0554ab7040dc145eb8ecb6a3d68635c82cf2a9ff665936953e4946041e2c42cde3c4fa8ad03a704c4614aafa6191cfbd68b0e273a3d22edc5b4dc2afdcb0a1f34bfcb8cd4f2bb46c98d6b5ab70e66cbb3cdb94eb6a7342ee7ef618b21024baf7c404a47d1418da89def391e37b8892a187ad36335c5d5385a0dd8a685b7be47cadc43e05d1a7551f6fe8302623de6cec27d43f31eb8a8a28d16472784fa2cb890b00ba22bcc94ca417e5e23ac0ddf5912a4278ca7c6753265818e63f3a25fe96a60ebfe03aeff89340f703ff1612e928b0800a153acf19ddc765730228575fed2dc9e78cdf2d7b0f96e2b084bde25a93e81e68a7b745206039703d633285cdf94a1f2861309b748ec2bb2bcaf4bc52d0a61176f434263a808260fb1d622c74f146f1d7c5
serverPrivateKey: 305ec317dbf2c70e6a168ef2a0b9a3ae822f92a371b5cff69257bb95c5c14e5b8ecfe3aff71fc8ca5c2cfccbee49cc0eed4f17961cc9bc4b416143f464c16c4457097db2d24b03efa63ce6c678b14129760f82797aeff8298e0476f43db6a9a0fd73936ce5ca50ee868bb8e5cb0762a2298173004fddbcada3328ed5e7565abf
serverPublicKey: c02624fbfd161afe1858c372aca1aaec9c55c6f57ed359a84e6030fbb3f32cb0d74585f6f159ba525d4e77a4988869dba37543696b641a1dc72b60a02126556fd2be1b366ca0b5cf1aa9799d8029ce9c78ec7b1b07b6a91c4ff855821ec0f9154d946671a4e940699bfb942308c56ad75c20e927c2384134c1c29154b39a33925d7b53f6e720ea6d0bd7f2598609f2734a483007f4d32d53c11d28684791d7fa0078087a7f550753b06805c71eaac00b47c85b152c196b021f38b9854093055d9c2d5ece913d7044e87caeb3378fe625a6a633a57a8ca1408e550e0c31c43011829dc51f077261a8889610eeed640c2e178366941a0ac92e4a779f5f08fb43c62343bbe9e0fdd76a4890188440e3e5b5b743c4654730f9e0d765a952c6ac30cfa4ea9a89cc00c26086e0acbef30d44f94f9efbb365c600073b51136e6f2efe9295089317d061977f7371f3aaff8858c85ad08495ebc6399297c1dad848515577ecd795bec3e9739f1e5b35e0e9fa8c0432fe1cd4cdef98168a39dec6e22acea4
clientPrivateKey: 938a2260126316088192dae254c67b14dcdda533a7dc37148d0b94a4fe6ba2aa4466bf258d79cd8442344e78d7f58170eaeb805c7c9abc1c4389606c91c05e4eb4532ca7088fe2bb2b75a1565710168313b566073b22a6c476455f8ce2a6fafe2f8e3d2d5270fae4c6704b40c5b61a586052b099f56b0f1f513fd0f9f0b7ec39
clientPublicKey: 95a2c74c1fe40ef0ecdbadc7ec264631cd5eabfa9a4107536333d62c7a1ee37c07cca024a6bae28085db76671968759634140c9d66ed4fce9d4071b88c21a2ef81983c121b8bf5db341e953f9a14177d71b9271b75a4710bb5b129a243aaa1d13145023920c7c1b819dc43cb69f02ffbc57da3abce13bcc1c2ff84e1ed6f3168e7874e864263ef7beb4d68a8e9176a0bf3ab6eb5ab4d53eb6600259aefc200b4dbeb6824b9311166dda21229304eb8c4672437d68358b8449241c4ad158b59e6ce5b0bb6a0bf0c5dd2788df74018798e14d76d09b7fa70c1cfae35d4ef291e6e844e280263a0ca5099a416c533902756a3a423260c76c28865946f770ca5a8330eaa6ea3e4a666dd9327b26c3793501b960ee76e2a011d162ad684ab4fbb7111462085f8904e83a808c168d932ea95e2724d7272fada649b7a2d7c9c5fc5ea34f37cfda7155c6c4e8eb5417289facf1cf1544fd6d3e92bb6b6bf18ace27079c960e53b6dd8e3d7d3171bedae95dc514c3766aa0c63813b5ab597406a55722169
expected client M: 3276a9b56eabca55cfe26ff1d2e03a055df30f1d
expected server HAMK: 78aa8b404999285e20990a14fad80d43c00fe2d3
clientK: 009f5ea712b7bf7863403309d92090980881bdba
clientM: 6913e56b1f61544cd012ec9e58a5262ec5a4ab25
```